### PR TITLE
Use keyrings location

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A PPA repository for SecureDNA packages
 # Usage
 
 ```bash
-sudo curl -SsL -o /etc/apt/trusted.gpg.d/securedna.gpg https://securedna.github.io/ppa/deb/securedna.gpg
-sudo curl -SsL -o /etc/apt/sources.list.d/securedna.list https://securedna.github.io/ppa/deb/securedna.list
+sudo curl -SsL https://securedna.github.io/ppa/deb/securedna.gpg | sudo tee /usr/share/keyrings/securedna-keyring.gpg > /dev/null
+sudo echo "deb [signed-by=/usr/share/keyrings/securedna-keyring.gpg] https://securedna.github.io/ppa/deb ./" | sudo tee /etc/apt/sources.list.d/securedna.list > /dev/null
 sudo apt update
 sudo apt install synthclient
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A PPA repository for SecureDNA packages
 # Usage
 
 ```bash
-sudo curl -SsL https://securedna.github.io/ppa/deb/securedna.gpg | sudo tee /usr/share/keyrings/securedna-keyring.gpg > /dev/null
-sudo echo "deb [signed-by=/usr/share/keyrings/securedna-keyring.gpg] https://securedna.github.io/ppa/deb ./" | sudo tee /etc/apt/sources.list.d/securedna.list > /dev/null
+curl -SsL https://securedna.github.io/ppa/deb/securedna.gpg | sudo tee /usr/share/keyrings/securedna-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/securedna-keyring.gpg] https://securedna.github.io/ppa/deb ./" | sudo tee /etc/apt/sources.list.d/securedna.list > /dev/null
 sudo apt update
 sudo apt install synthclient
 ```

--- a/deb/securedna.list
+++ b/deb/securedna.list
@@ -1,1 +1,0 @@
-deb [signed-by=/etc/apt/trusted.gpg.d/securedna.gpg] https://securedna.github.io/ppa/deb ./


### PR DESCRIPTION
Remove `list` file and inline it in the readme.

Move GPG key from trusted.gpg.d to keyring. For more info on security implications read https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution